### PR TITLE
add:ユーザー情報詳細の実装　#45

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+
+class UserController extends Controller
+{
+    public function show($id)
+    {
+        
+        $user = User::findOrFail($id);
+        //ログインしているアカウント出ない場合検索画面にリダイレクト
+        if($user->id != Auth::id()){
+            return redirect()->route('product.index')->with('message','不適切なURLです');
+        }else{
+            return view('users.show',['user'=> $user]);   
+        }
+    }      
+}

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+
+class UsersController extends Controller
+{
+    public function show($id)
+    {
+        
+        $user = User::findOrFail($id);
+        $user->fullAddress = $user->getFullAddress();
+        $user->fullName = $user->getFullName();
+        //ログインしているアカウント出ない場合検索画面にリダイレクト
+        if($user->id != Auth::id()){
+            return redirect()->route('product.index')->with('message','不適切なURLです');
+        }else{
+            return view('users.show',['user'=> $user]);   
+        }
+    }      
+ }

--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -12,7 +12,7 @@ class TrustProxies extends Middleware
      *
      * @var array|string
      */
-    protected $proxies;
+    protected $proxies='*';
 
     /**
      * The headers that should be used to detect proxies.

--- a/resources/views/product/search.blade.php
+++ b/resources/views/product/search.blade.php
@@ -1,13 +1,20 @@
 @extends('layouts.app')
 
 @section('content')
+
+@if (session('message'))
+    <div class="alert alert-danger text-center">
+        {{ session('message') }}
+    </div>
+@endif
+　
 <div class="product">
     <div class="row mt-4">
         <div class="col-lg-12 text-center">
             <h1>商品検索画面</h1>
         </div>
     </div>
-
+    
     <form class="search" enctype="multipart/form-data" action="{{route('product.index')}}" accept-charset="UTF-8" method="get">
         @csrf
         <div class="row">

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -10,13 +10,13 @@
     </div>
     <div class="row mb-5 h4">
       <div class="col-sm-4 col-5 text-center">氏名</div>
-      <div class="col-sm-4 col-5">{{ $user->last_name }} {{ $user->first_name }}</div>
+      <div class="col-sm-4 col-5">{{ $user->fullName }}</div>
     </div>
     <div class="row mb-5 h4">
       <div class="col-sm-4 col-5 text-center">住所</div>
       <div class="col-sm-4 col-5">
         <p>〒{{ $user->zipcode }}</p>
-        <p>{{ $user->prefecture }} {{ $user->municipality }} {{ $user->address }} {{ $user->apartments }}</p>
+        <p>{{ $user->fullAddress }}</p>
       </div>
     </div>
     <div class="row mb-5 h4">

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -1,0 +1,36 @@
+@extends('layouts.app')
+
+@section('content')
+　
+  <div class="container mt-5">
+    <h1 class="text-center py-5">ユーザー情報</h1>
+    <div class="row mb-5 h4">
+      <div class="col-sm-4 col-5 text-center">ユーザーID</div>
+      <div class="col-sm-4 col-5">{{$user->id }}</div>
+    </div>
+    <div class="row mb-5 h4">
+      <div class="col-sm-4 col-5 text-center">氏名</div>
+      <div class="col-sm-4 col-5">{{ $user->last_name }} {{ $user->first_name }}</div>
+    </div>
+    <div class="row mb-5 h4">
+      <div class="col-sm-4 col-5 text-center">住所</div>
+      <div class="col-sm-4 col-5">
+        <p>〒{{ $user->zipcode }}</p>
+        <p>{{ $user->prefecture }} {{ $user->municipality }} {{ $user->address }} {{ $user->apartments }}</p>
+      </div>
+    </div>
+    <div class="row mb-5 h4">
+      <div class="col-sm-4 col-5 text-center">電話番号</div>
+      <div class="col-sm-4 col-5">{{ $user->phone_number }}</div>
+    </div>
+    <div class="row mb-5 h4">
+      <div class="col-sm-4 col-5 text-center">メールアドレス</div>
+      <div class="col-sm-4 col-5">{{$user->email  }}</div>
+    </div>
+    <div class="text-center col-auto px-3 my-3">
+      <a href="" class="btn btn-primary col-auto">修正/退会する</a>
+    </div>
+  </div>
+
+
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -33,3 +33,5 @@ Route::prefix('order')->group(function () {
 
 Route::get('orderHistory{all}', 'OrdersController@index')->name('order.all');
 Route::get('orderHistory{three}', 'OrdersController@index')->name('order.threeSeach');
+
+Route::get('user/{id}','UserController@show')->name('user.show');

--- a/routes/web.php
+++ b/routes/web.php
@@ -34,4 +34,4 @@ Route::prefix('order')->group(function () {
 Route::get('orderHistory{all}', 'OrdersController@index')->name('order.all');
 Route::get('orderHistory{three}', 'OrdersController@index')->name('order.threeSeach');
 
-Route::get('user/{id}','UserController@show')->name('user.show');
+Route::get('users/{id}','UsersController@show')->name('user.show');


### PR DESCRIPTION
@hsg0830 さん

お疲れ様です！
お忙しいところ、度々申し訳ございません！

ECサイトのユーザー情報詳細の実装が完了しましたので、お手すきの際にご確認のほどよろしくお願いいたします。

■やったこと
・ユーザー詳細画面へのルーティングを追加
・ユーザー詳細画面を返すコントローラーを作成し、アクションを追加
・ユーザー詳細画面の実装
・ログインしていないアカウントの場合、商品検索画面にリダイレクトしフラッシュメッセージを表示するよう設定

■考慮してほしいこと
・ユーザー情報修正/退会の実装がまだのためユーザ詳細画面での修正/退会する`href`は設定はしていません。
・ユーザ詳細画面の`show.blade`にて氏名や住所などデータが連続する場合`{{ $user->カラム}}`を１つずつ記述していますが、こちらの書き方でもよろしいでしょうか？

どうぞ宜しくお願い致します。