### PR TITLE
ユーザー更新画面の実装 #46

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -20,18 +20,14 @@ class UsersController extends Controller
         //ログインしているアカウント出ない場合検索画面にリダイレクト
         //if($user->id != Auth::id()){
             //return redirect()->route('product.index')->with('message','不適切なURLです');
-        //}else{
             return view('users.show',['user'=> $user]);   
-        //}
     }
     public function getEdit($id){
         
         $user = User::findOrFail($id);
         // if($user->id != Auth::id()){
         //     return redirect()->route('product.index')->with('message','不適切なURLです');
-        // }else{
             return view('users.edit',['user'=>$user]);
-        // }
     } 
     
     public function postEdit(UserRequest $request, $id){
@@ -40,8 +36,6 @@ class UsersController extends Controller
         
         // if($user->id != Auth::id()){
         //     return redirect()->route('product.index')->with('message','不適切なURLです');
-        // }else{
-        
         
         $user->last_name = $request->last_name;
         $user->first_name = $request->first_name;
@@ -55,7 +49,6 @@ class UsersController extends Controller
         $user->save();
         
         return redirect()->route('user.show',$user->id);
-        // }
     } 
     
     public function destroy($id){

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -5,21 +5,64 @@ namespace App\Http\Controllers;
 use App\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Validator;
+use App\Http\Requests\UserRequest;
+use Illuminate\Validation\Rule;
 
 
 class UsersController extends Controller
 {
-    public function show($id)
-    {
+    public function show($id){
         
         $user = User::findOrFail($id);
         $user->fullAddress = $user->getFullAddress();
         $user->fullName = $user->getFullName();
         //ログインしているアカウント出ない場合検索画面にリダイレクト
-        if($user->id != Auth::id()){
-            return redirect()->route('product.index')->with('message','不適切なURLです');
-        }else{
+        //if($user->id != Auth::id()){
+            //return redirect()->route('product.index')->with('message','不適切なURLです');
+        //}else{
             return view('users.show',['user'=> $user]);   
-        }
-    }      
+        //}
+    }
+    public function getEdit($id){
+        
+        $user = User::findOrFail($id);
+        // if($user->id != Auth::id()){
+        //     return redirect()->route('product.index')->with('message','不適切なURLです');
+        // }else{
+            return view('users.edit',['user'=>$user]);
+        // }
+    } 
+    
+    public function postEdit(UserRequest $request, $id){
+        
+        $user = User::find($request->id);
+        
+        // if($user->id != Auth::id()){
+        //     return redirect()->route('product.index')->with('message','不適切なURLです');
+        // }else{
+        
+        
+        $user->last_name = $request->last_name;
+        $user->first_name = $request->first_name;
+        $user->zipcode = $request->zipcode;
+        $user->prefecture = $request->prefecture;
+        $user->municipality = $request->municipality;
+        $user->address = $request->address;
+        $user->apartments = $request->apartments;
+        $user->email = $request->email;
+        $user->phone_number = $request->phone_number;
+        $user->save();
+        
+        return redirect()->route('user.show',$user->id);
+        // }
+    } 
+    
+    public function destroy($id){
+        $user = User::findOrFail($id);
+        $user->delete();
+        
+        return view('top');
+    }
+    
  }

--- a/app/Http/Requests/UserRequest.php
+++ b/app/Http/Requests/UserRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UserRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+        'last_name' =>['required','string','max:10'],
+        'first_name' =>['required','string','max:10'],
+        'zipcode' =>['required','string','alpha_dash','max:8'],
+        'prefecture'=>['required','string','max:5'],
+        'municipality' =>['required','string','max:10'],
+        'address' =>['required','string','max:15'],
+        'email' =>['email','string',Rule::unique('m_users')->ignore($this->id)],
+        'phone_number'=>['required','string','alpha_dash','max:15'],
+        ];
+    }
+}

--- a/app/Http/Requests/UserRequest.php
+++ b/app/Http/Requests/UserRequest.php
@@ -31,7 +31,7 @@ class UserRequest extends FormRequest
         'prefecture'=>['required','string','max:5'],
         'municipality' =>['required','string','max:10'],
         'address' =>['required','string','max:15'],
-        'email' =>['email','string',Rule::unique('m_users')->ignore($this->id)],
+        'email' =>['email',Rule::unique('m_users')->ignore($this->id)],
         'phone_number'=>['required','string','alpha_dash','max:15'],
         ];
     }

--- a/app/User.php
+++ b/app/User.php
@@ -47,6 +47,12 @@ class User extends Authenticatable
     protected $hidden = [
         'password',
     ];
+    
+    
+    protected $dates = [
+        'deleted_at'
+    ];
+
 
     public function userClassification()
     {

--- a/auth.php
+++ b/auth.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Authentication Language Lines
+    | 認証言語
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used during authentication for various
+    | messages that we need to display to the user. You are free to modify
+    | these language lines according to your application's requirements.
+    |
+    | 次の言語行は、ユーザーに表示する必要のあるさまざまなメッセージの認証時に使用されます。
+    | これらの言語の行は、アプリケーションの要件に応じて自由に変更できます。
+    */
+
+    'failed' => '認証に失敗しました',
+    'throttle' => 'ログイン試行回数が制限に達しました。 :seconds 秒以上開けて再度お試しください',
+
+];

--- a/pagination.php
+++ b/pagination.php
@@ -1,0 +1,20 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Pagination Language Lines
+    | ページネーション言語
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'previous' => '&laquo; 前へ',
+    'next' => '次へ &raquo;',
+
+];

--- a/resources/lang/ja/auth.php
+++ b/resources/lang/ja/auth.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Authentication Language Lines
+    | 認証言語
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used during authentication for various
+    | messages that we need to display to the user. You are free to modify
+    | these language lines according to your application's requirements.
+    |
+    | 次の言語行は、ユーザーに表示する必要のあるさまざまなメッセージの認証時に使用されます。
+    | これらの言語の行は、アプリケーションの要件に応じて自由に変更できます。
+    */
+
+    'failed' => '認証に失敗しました',
+    'throttle' => 'ログイン試行回数が制限に達しました。 :seconds 秒以上開けて再度お試しください',
+
+];

--- a/resources/lang/ja/pagination.php
+++ b/resources/lang/ja/pagination.php
@@ -1,0 +1,20 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Pagination Language Lines
+    | ページネーション言語
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'previous' => '&laquo; 前へ',
+    'next' => '次へ &raquo;',
+
+];

--- a/resources/lang/ja/password.php
+++ b/resources/lang/ja/password.php
@@ -1,0 +1,23 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Password Reset Language Lines
+    | パスワードリセット言語
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are the default lines which match reasons
+    | that are given by the password broker for a password update attempt
+    | has failed, such as for an invalid token or invalid new password.
+    |
+    */
+
+    'password' => 'パスワードは６字以上、かつ、確認用と一致している必要があります',
+    'reset' => 'パスワードがリセットされました',
+    'sent' => 'パスワードリセットリンクが電子メールで送信されました',
+    'token' => 'このパスワードリセットトークンは無効です',
+    'user' => "ユーザーは存在しません",
+
+];

--- a/resources/lang/ja/validation.php
+++ b/resources/lang/ja/validation.php
@@ -1,0 +1,170 @@
+<?php
+
+return [
+
+    /*
+      |--------------------------------------------------------------------------
+      | Validation Language Lines
+      | 検証言語
+      |--------------------------------------------------------------------------
+      |
+      | The following language lines contain the default error messages used by
+      | the validator class. Some of these rules have multiple versions such
+      | as the size rules. Feel free to tweak each of these messages here.
+      |
+      | 次の言語行には、バリデータークラスで使用されるデフォルトのエラーメッセージが含まれています。
+      | これらの規則の中には、サイズ規則などの複数のバージョンがあります。
+      | これらのメッセージのそれぞれをここで微調整してください。
+    */
+
+    'accepted'             => ':attribute が未承認です',
+    'active_url'           => ':attribute は有効なURLではありません',
+    'after'                => ':attribute は :date より後の日付にしてください',
+    'after_or_equal'       => ':attribute は :date 以降の日付にしてください',
+    'alpha'                => ':attribute は英字のみ有効です',
+    'alpha_dash'           => ':attribute は「英字」「数字」「-(ダッシュ)」「_(下線)」のみ有効です',
+    'alpha_num'            => ':attribute は「英字」「数字」のみ有効です',
+    'array'                => ':attribute は配列タイプのみ有効です',
+    'before'               => ':attribute は :date より前の日付にしてください',
+    'before_or_equal'      => ':attribute は :date 以前の日付にしてください',
+    'between'              => [
+        'numeric' => ':attribute は :min ～ :max までの数値まで有効です',
+        'file'    => ':attribute は :min ～ :max キロバイトまで有効です',
+        'string'  => ':attribute は :min ～ :max 文字まで有効です',
+        'array'   => ':attribute は :min ～ :max 個まで有効です',
+    ],
+    'boolean'              => ':attribute の値は true もしくは false のみ有効です',
+    'confirmed'            => ':attribute を確認用と一致させてください',
+    'date'                 => ':attribute を有効な日付形式にしてください',
+    'date_format'          => ':attribute を :format 書式と一致させてください',
+    'different'            => ':attribute を :other と違うものにしてください',
+    'digits'               => ':attribute は :digits 桁のみ有効です',
+    'digits_between'       => ':attribute は :min ～ :max 桁のみ有効です',
+    'dimensions'           => ':attribute ルールに合致する画像サイズのみ有効です',
+    'distinct'             => ':attribute に重複している値があります',
+    'email'                => ':attribute メールアドレスの書式のみ有効です',
+    'exists'               => ':attribute 無効な値です',
+    'file'                 => ':attribute アップロード出来ないファイルです',
+    'filled'               => ':attribute 値を入力してください',
+    'gt'                   => [
+        'numeric' => ':attribute は :value より大きい必要があります。',
+        'file'    => ':attributeは :value キロバイトより大きい必要があります。',
+        'string'  => ':attribute は :value 文字より多い必要があります。',
+        'array'   => ':attribute には :value 個より多くの項目が必要です。',
+    ],
+    'gte'                  => [
+        'numeric' => ':attribute は :value 以上である必要があります。',
+        'file'    => ':attribute は :value キロバイト以上である必要があります。',
+        'string'  => ':attribute は :value 文字以上である必要があります。',
+        'array'   => ':attribute には value 個以上の項目が必要です。',
+    ],
+    'image'                => ':attribute 画像は「jpg」「png」「bmp」「gif」「svg」のみ有効です',
+    'in'                   => ':attribute 無効な値です',
+    'in_array'             => ':attribute は :other と一致する必要があります',
+    'integer'              => ':attribute は整数のみ有効です',
+    'ip'                   => ':attribute IPアドレスの書式のみ有効です',
+    'ipv4'                 => ':attribute IPアドレス(IPv4)の書式のみ有効です',
+    'ipv6'                 => ':attribute IPアドレス(IPv6)の書式のみ有効です',
+    'json'                 => ':attribute 正しいJSON文字列のみ有効です',
+    'lt'                   => [
+        'numeric' => ':attribute は :value 未満である必要があります。',
+        'file'    => ':attribute は :value キロバイト未満である必要があります。',
+        'string'  => ':attribute は :value 文字未満である必要があります。',
+        'array'   => ':attribute は :value 未満の項目を持つ必要があります。',
+    ],
+    'lte'                  => [
+        'numeric' => ':attribute は :value 以下である必要があります。',
+        'file'    => ':attribute は :value キロバイト以下である必要があります。',
+        'string'  => ':attribute は :value 文字以下である必要があります。',
+        'array'   => ':attribute は :value 以上の項目を持つ必要があります。',
+    ],
+    'max'                  => [
+        'numeric' => ':attribute は :max 以下のみ有効です',
+        'file'    => ':attribute は :max KB以下のファイルのみ有効です',
+        'string'  => ':attribute は :max 文字以下のみ有効です',
+        'array'   => ':attribute は :max 個以下のみ有効です',
+    ],
+    'mimes'                => ':attribute は :values タイプのみ有効です',
+    'mimetypes'            => ':attribute は :values タイプのみ有効です',
+    'min'                  => [
+        'numeric' => ':attribute は :min 以上のみ有効です',
+        'file'    => ':attribute は :min KB以上のファイルのみ有効です',
+        'string'  => ':attribute は :min 文字以上のみ有効です',
+        'array'   => ':attribute は :min 個以上のみ有効です',
+    ],
+    'not_in'               => ':attribute 無効な値です',
+    'not_regex'            => 'The :attribute format is invalid.',
+    'numeric'              => ':attribute は数字のみ有効です',
+    'present'              => ':attribute が存在しません',
+    'regex'                => ':attribute 無効な値です',
+    'required'             => ':attribute は必須です',
+    'required_if'          => ':attribute は :other が :value には必須です',
+    'required_unless'      => ':attribute は :other が :values でなければ必須です',
+    'required_with'        => ':attribute は :values が入力されている場合は必須です',
+    'required_with_all'    => ':attribute は :values が入力されている場合は必須です',
+    'required_without'     => ':attribute は :values が入力されていない場合は必須です',
+    'required_without_all' => ':attribute は :values が入力されていない場合は必須です',
+    'same'                 => ':attribute は :other と同じ場合のみ有効です',
+    'size'                 => [
+        'numeric' => ':attribute は :size のみ有効です',
+        'file'    => ':attribute は :size KBのみ有効です',
+        'string'  => ':attribute は :size 文字のみ有効です',
+        'array'   => ':attribute は :size 個のみ有効です',
+    ],
+    'string'               => ':attribute は文字列のみ有効です',
+    'timezone'             => ':attribute 正しいタイムゾーンのみ有効です',
+    'unique'               => ':attribute は既に存在します',
+    'uploaded'             => ':attribute アップロードに失敗しました',
+    'url'                  => ':attribute は正しいURL書式のみ有効です',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom Validation Language Lines
+    | カスタム検証言語
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify custom validation messages for attributes using the
+    | convention "attribute.rule" to name the lines. This makes it quick to
+    | specify a specific custom language line for a given attribute rule.
+    |
+    | ここでは、行に名前を付けるために "attribute.rule"という規則を使って属性のカスタム
+    | 検証メッセージを指定することができます。 これにより、特定の属性ルールに対して特定の
+    | カスタム言語行をすばやく指定できます。
+    |
+    */
+
+    'custom' => [
+        'attribute-name' => [
+            'rule-name' => 'custom-message',
+        ],
+    ],
+
+    /*
+      |--------------------------------------------------------------------------
+      | Custom Validation Attributes
+      | カスタム検証属性
+      |--------------------------------------------------------------------------
+      |
+      | The following language lines are used to swap attribute place-holders
+      | with something more reader friendly such as E-Mail Address instead
+      | of "email". This simply helps us make messages a little cleaner.
+      |
+      | 次の言語行は、属性プレースホルダを「email」ではなく「E-Mail Address」などの
+      | 読みやすいものと交換するために使用されます。
+      |
+    */
+
+    'attributes' => [
+        'last_name'=>'名字',
+        'first_name'=>'名前',
+        'zipcode'=>'郵便番号',
+        'prefecture'=>'都道府県',
+        'municipality'=>'市町村区',
+        'address'=>'番地',
+        'apartments'=>'マンション部屋番号',
+        'email'=>'メールアドレス',
+        'phone_number'=>'電話番号',
+    
+    ],
+
+];

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -14,11 +14,11 @@
         <label class="col-sm-2 text-sm-center offset-sm-1">氏名</label>
         <label class="col-sm-1 text-sm-right col-2 col-form-label">姓</label>
         <div class="col-sm-2">
-          <input type="text" class="form-control" name="last_name" value="{{ old('last_name',$user->last_name) }}" placeholder="探求">
+          <input type="text" class="form-control" name="last_name" value="{{ old('last_name',$user->last_name) }}" placeholder="◯◯">
         </div>
         <label class="col-sm-1 text-sm-right col-2 col-form-label">名</label>
         <div class="col-sm-2">
-          <input type="text" class="form-control"  name="first_name" value="{{ old('first_name',$user->first_name) }}" placeholder="学">
+          <input type="text" class="form-control"  name="first_name" value="{{ old('first_name',$user->first_name) }}" placeholder="XX">
         </div>
       </div>
 

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -1,0 +1,80 @@
+@extends('layouts.app')
+
+@section('content')
+
+<div class="container">
+  @include('users.user_error')
+    <h1 class="text-center py-5">ユーザー情報修正</h1>
+    <form class="form-group" action="{{ route('user.postEdit',$user->id) }}" method="post" enctype="multipart/form-data" accept-charset="UTF-8">
+      <input type="hidden" name="id" value="{{$user->id}}" />
+      {{ csrf_field() }}
+      {{ method_field('put') }}
+      
+      <div class="form-group row">
+        <label class="col-sm-2 text-sm-center offset-sm-1">氏名</label>
+        <label class="col-sm-1 text-sm-right col-2 col-form-label">姓</label>
+        <div class="col-sm-2">
+          <input type="text" class="form-control" name="last_name" value="{{ old('last_name',$user->last_name) }}" placeholder="探求">
+        </div>
+        <label class="col-sm-1 text-sm-right col-2 col-form-label">名</label>
+        <div class="col-sm-2">
+          <input type="text" class="form-control"  name="first_name" value="{{ old('first_name',$user->first_name) }}" placeholder="学">
+        </div>
+      </div>
+
+      <div class="form-group row">
+        <label class="col-sm-2 text-sm-center col-12 col-form-label offset-sm-1">住所</label>
+        <label class="col-sm-1 text-right col-2 col-form-label">〒</label>
+        <div class="col-sm-3 col-8">
+          <input type="text" class="form-control"  name="zipcode" value="{{ old('zipcode',$user->zipcode) }}" placeholder="0000000">
+        </div>
+      </div>
+      <div class="form-group row">
+        <label class="col-sm-4 col-form-label text-sm-right">都道府県</label>
+        <div class="col-sm-4">
+          <input type="text" class="form-control"  name="prefecture" value="{{ old('prefecture',$user->prefecture) }}" placeholder="富山県">
+        </div>
+      </div>
+      <div class="form-group row">
+        <label class="col-sm-4 col-form-label text-sm-right">市町村区</label>
+        <div class="col-sm-4">
+          <input type="text" class="form-control"  name="municipality" value="{{ old('municipality',$user->municipality) }}" placeholder="南〇市">
+        </div>
+      </div>
+      <div class="form-group row">
+        <label class="col-sm-4 col-form-label text-sm-right">番地</label>
+        <div class="col-sm-4">
+          <input type="text" class="form-control"  name="address" value="{{ old('address',$user->address) }}" placeholder="">
+        </div>
+      </div>
+      <div class="form-group row">
+        <label class="col-sm-4 col-form-label text-sm-right">マンション部屋番号</label>
+        <div class="col-sm-4">
+          <input type="text" class="form-control"  name="apartment" value="{{ old('apartment',$user->apartment) }}"　placeholder="">
+        </div>
+      </div>
+      <div class="form-group row">
+        <label class="col-sm-4 col-form-label text-sm-center">メールアドレス</label>
+        <div class="col-sm-6">
+          <input type="text" class="form-control"  name="email" value="{{ old('email',$user->email) }}" placeholder="email@example.com">
+        </div>
+      </div>
+      <div class="form-group row">
+        <label class="col-sm-4 col-form-label text-sm-center">電話番号</label>
+        <div class="col-sm-6">
+          <input type="text" class="form-control"  name="phone_number" value="{{ old('phone_number',$user->phone_number) }}" placeholder="〇〇〇〇〇〇〇〇〇〇">
+        </div>
+      </div>
+      <div class="d-flex justify-content-around py-5 col-sm-8 col-auto container">
+      <input type="submit" name="submit" value="修正" class="btn btn-primary px-2">
+    </form>
+    
+    <form class="form-group-row" action="{{ route('user.destroy',$user->id)}}" method="post">
+      {{ csrf_field() }}
+      {{ method_field('delete') }}
+      <input type="submit" name="submit" value="退会" class="btn btn-danger px-2">  
+    </form>
+    </div>
+  </div>
+
+  @endsection

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -28,7 +28,7 @@
       <div class="col-sm-4 col-5">{{$user->email  }}</div>
     </div>
     <div class="text-center col-auto px-3 my-3">
-      <a href="" class="btn btn-primary col-auto">修正/退会する</a>
+      <a href="{{ route('user.edit',$user->id) }}" class="btn btn-primary col-auto">修正/退会する</a>
     </div>
   </div>
 

--- a/resources/views/users/user_error.blade.php
+++ b/resources/views/users/user_error.blade.php
@@ -1,0 +1,7 @@
+@if (count($errors) > 0)
+    <ul class="alert alert-danger">
+        @foreach ($errors->all() as $error)
+            <li class="ml-4">{{ $error }}</li>
+        @endforeach
+    </ul>
+@endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -34,4 +34,8 @@ Route::prefix('order')->group(function () {
 Route::get('orderHistory{all}', 'OrdersController@index')->name('order.all');
 Route::get('orderHistory{three}', 'OrdersController@index')->name('order.threeSeach');
 
-Route::get('users/{id}','UsersController@show')->name('user.show');
+
+    Route::get('users/{id}','UsersController@show')->name('user.show');
+    Route::get('edit/{id}','UsersController@getEdit')->name('user.edit');
+    Route::put('update/{id}','UsersController@postEdit')->name('user.postEdit');
+    Route::delete('destroy/{id}','UsersController@destroy')->name('user.destroy');


### PR DESCRIPTION
@hsg0830 

お疲れ様です！

ユーザー更新画面の実装が完了しましたので、ご確認のほどよろしくお願い致します。

■やったこと  
・ユーザー更新画面、退会のルーティングを追加
・ユーザー更新画面、退会後を返すコントローラーを作成し、アクションを追加  
・ユーザー更新画面の実装  
・ログインしていないアカウントの場合、商品検索画面にリダイレクトしフラッシュメッセージを表示するよう設定
・バリデーションの日本語化
・ユーザー詳細画面の修正/退会するボタンから編集画面にルート設定


■考慮してほしいこと  
・ダミーデータでのユーザー情報編集、退会の操作後tinkerで変更確認済ですが、退会処理は初めてなので、懸念等ございましたらご教示ただけると幸いです。
・新規登録からのログインしてる状態での動作確認ができないため前回と同様UsersControllerでのAuth部分をコメントアウトし、ユーザー情報編集、退会の動作確認と、コメントアウト解除をしログイン以外でのリダイレクトした場合の商品検索画面へのリダイレクトの動作確認済です。

お忙しいところを恐れ入りますが、どうぞ宜しくお願い致します。