### PR TITLE
注文詳細、履歴、商品検索部分の修正

### DIFF
--- a/app/Http/Controllers/OrdersController.php
+++ b/app/Http/Controllers/OrdersController.php
@@ -130,12 +130,10 @@ class OrdersController extends Controller
         // 合計
         $totalPrice = 0;
         foreach ($orderQuantityMatchs as $orderQuantityMatch) {
-            if ($orderQuantityMatch->shipment_status_id === 1) {
                 $price = $orderQuantityMatch->product['price'];
                 $order_quantity = $orderQuantityMatch['order_quantity'];
                 $total = $price * $order_quantity;
                 $totalPrice += $total;
-            }
         }
 
         //ユーザー

--- a/app/Http/Controllers/OrdersController.php
+++ b/app/Http/Controllers/OrdersController.php
@@ -150,30 +150,12 @@ class OrdersController extends Controller
      */
     public function destroy($id)
     {
+        //注文id取得
         $order = Order::findOrFail($id);
 
-        //注文詳細
-        $details = $order->orderDetails;
-        foreach ($details as $detail) {
-            $product_id = $detail->product_id;
-            $order_quantity = $detail->order_quantity;
-            $order_detail_number = $detail->order_detail_number;
-        }
-
-        //ユーザーIDと注文番号で一致
-        $orderQuantityMatchs = OrderDetail::where('order_detail_number', $order_detail_number)
-            ->with('product')
-            ->get();
-
-        // 削除
-        foreach ($orderQuantityMatchs as $orderQuantityMatch) {
-            $id = $orderQuantityMatch->order['id'];
-            $orders = Order::findOrFail([$id]);
-
-            foreach ($orders as $order) {
-                $order->delete();
-            }
-        }
-        return view('order.details');
+        //削除
+        $order->delete();
+        
+        return redirect()->action('OrdersController@index', ['id' => 'all']);
     }
 }

--- a/resources/views/order/details.blade.php
+++ b/resources/views/order/details.blade.php
@@ -30,7 +30,7 @@
             <div class="text-right px-3 my-3">
                 @if($detail->shipment_status_id === 1)
                     @if ($loop->first)
-                        <form class="btn btn-sm bg-danger" action="{{route('order.destroy', ['detail' => $detail])}}" method="post">
+                        <form class="btn btn-sm bg-danger" action="{{route('order.destroy', ['detail' => $detail->order_id])}}" method="post">
                             @csrf
                             @method('delete')
                             <input type="submit" value="&#xf1f8; 注文をキャンセルする" class="btn btn-danger" style="border: 0px none; color:white;" onclick='return confirm("削除しますか？");'>

--- a/resources/views/order/details.blade.php
+++ b/resources/views/order/details.blade.php
@@ -54,14 +54,14 @@
                 <th class="text-center">詳細</th>
             </tr>
         </thead>
+        
+    @if(isset($orderQuantityMatchs))
         <tbody class="text-center border-bottom">
-            @if(isset($orderQuantityMatchs))
                 @foreach($orderQuantityMatchs as $orderQuantityMatch)
                     @php
                     $total=$orderQuantityMatch->product->price * $orderQuantityMatch->order_quantity;
                     @endphp
                     <tr>
-                        @if($orderQuantityMatch->shipment_status_id === 1)
                             <td>{{$orderQuantityMatch->product->id}}</td>
                             <td>{{$orderQuantityMatch->product->product_name}}</td>
                             <td>{{$orderQuantityMatch->product->category->category_name}}</td>
@@ -69,16 +69,21 @@
                             <td>{{$orderQuantityMatch->order_quantity}}</td>
                             <td>{{$total}}</td>
                             <td>
-                                注文状態:発送前
+                            注文状態：
+                            @if($orderQuantityMatch->shipment_status_id === 1)
+                                 発送前
+                                 @elseif($orderQuantityMatch->shipment_status_id === 2)
+                                 発送中
+                                 @else
+                                 発送済み
+                            @endif                           
                             </td>
                             <td><a href="{{ route('product.show', ['id' => $orderQuantityMatch->product_id]) }}" class="btn btn-primary">商品詳細</a></td>
-                        @endif
                     </tr>
                 @endforeach
         </tbody>
         <tbody class="text-center">
             <tr>
-                @if($orderQuantityMatch->shipment_status_id === 1)
                 <td></td>
                 <td></td>
                 <td></td>
@@ -87,13 +92,9 @@
                 <td>{{$totalPrice}}円</td>
                 <td></td>
                 <td></td>
-                @else
-                注文前はありません。<br>
-                注文履歴画面に戻り、やり直してください。
-                @endif
             </tr>
-            @endif
         </tbody>
+    @endif
     </table>
     <div class="text-right px-3 my-3">
         <a href="{{route('order.all',['id'=>'all'])}}" class="btn btn-primary">注文履歴に戻る</a>

--- a/resources/views/order/details.blade.php
+++ b/resources/views/order/details.blade.php
@@ -18,23 +18,27 @@
     </div>
 
     @if(isset($details))
-    @foreach($details as $detail)
-    <div class="py-3">
-        <p>注文番号：
-            {{$detail->order_detail_number}}
-        </p>
-    </div>
+        @foreach($details as $detail)
+            @if ($loop->first)
+                <div class="py-3">
+                    <p>注文番号：
+                        {{$detail->order_detail_number}}
+                    </p>
+                </div>
+            @endif
 
-    <div class="text-right px-3 my-3">
-        @if($detail->shipment_status_id === 1)
-        <form class="btn btn-sm bg-danger" action="{{route('order.destroy', ['detail' => $detail])}}" method="post">
-            @csrf
-            @method('delete')
-            <input type="submit" value="&#xf1f8; 注文をキャンセルする" class="btn btn-danger" style="border: 0px none; color:white;" onclick='return confirm("削除しますか？");'>
-        </form>
-        @endif
-    </div>
-    @endforeach
+            <div class="text-right px-3 my-3">
+                @if($detail->shipment_status_id === 1)
+                    @if ($loop->first)
+                        <form class="btn btn-sm bg-danger" action="{{route('order.destroy', ['detail' => $detail])}}" method="post">
+                            @csrf
+                            @method('delete')
+                            <input type="submit" value="&#xf1f8; 注文をキャンセルする" class="btn btn-danger" style="border: 0px none; color:white;" onclick='return confirm("削除しますか？");'>
+                        </form>
+                    @endif
+                @endif
+            </div>
+        @endforeach
     @endif
 
     <table class="table">

--- a/resources/views/order/details.blade.php
+++ b/resources/views/order/details.blade.php
@@ -51,28 +51,30 @@
                 <th class="text-center">個数</th>
                 <th class="text-center">小計</th>
                 <th class="text-center">備考</th>
+                <th class="text-center">詳細</th>
             </tr>
         </thead>
         <tbody class="text-center border-bottom">
             @if(isset($orderQuantityMatchs))
-            @foreach($orderQuantityMatchs as $orderQuantityMatch)
-            @php
-            $total=$orderQuantityMatch->product->price * $orderQuantityMatch->order_quantity;
-            @endphp
-            <tr>
-                @if($orderQuantityMatch->shipment_status_id === 1)
-                <td>{{$orderQuantityMatch->product->id}}</td>
-                <td>{{$orderQuantityMatch->product->product_name}}</td>
-                <td>{{$orderQuantityMatch->product->category->category_name}}</td>
-                <td>{{$orderQuantityMatch->product->price}}</td>
-                <td>{{$orderQuantityMatch->order_quantity}}</td>
-                <td>{{$total}}</td>
-                <td>
-                    注文状態:発送前
-                </td>
-                @endif
-            </tr>
-            @endforeach
+                @foreach($orderQuantityMatchs as $orderQuantityMatch)
+                    @php
+                    $total=$orderQuantityMatch->product->price * $orderQuantityMatch->order_quantity;
+                    @endphp
+                    <tr>
+                        @if($orderQuantityMatch->shipment_status_id === 1)
+                            <td>{{$orderQuantityMatch->product->id}}</td>
+                            <td>{{$orderQuantityMatch->product->product_name}}</td>
+                            <td>{{$orderQuantityMatch->product->category->category_name}}</td>
+                            <td>{{$orderQuantityMatch->product->price}}</td>
+                            <td>{{$orderQuantityMatch->order_quantity}}</td>
+                            <td>{{$total}}</td>
+                            <td>
+                                注文状態:発送前
+                            </td>
+                            <td><a href="{{ route('product.show', ['id' => $orderQuantityMatch->product_id]) }}" class="btn btn-primary">商品詳細</a></td>
+                        @endif
+                    </tr>
+                @endforeach
         </tbody>
         <tbody class="text-center">
             <tr>

--- a/resources/views/order/history.blade.php
+++ b/resources/views/order/history.blade.php
@@ -33,7 +33,9 @@
                     <td>{{$order->id}}</td>
                     <td>
                         @foreach($order->orderDetails as $orderDetail)
-                        {{$orderDetail->order_detail_number}}
+                            @if ($loop->first)
+                            {{$orderDetail->order_detail_number}}
+                            @endif
                         @endforeach
                     </td>
                     <td>

--- a/resources/views/order/history.blade.php
+++ b/resources/views/order/history.blade.php
@@ -56,13 +56,15 @@
                         <p>注文日時: {{$order->updated_at->format('Y/m/d')}}</p>
                         <p>注文状態:
                             @foreach($order->orderDetails as $key =>$orderDetail)
-                            @if($orderDetail->shipmentStatus->shipment_status_name==='1')
-                            発送前
-                            @elseif($orderDetail->shipmentStatus->shipment_status_name==='2')
-                            発送中
-                            @else
-                            発送済み
-                            @endif
+                                @if ($loop->first)
+                                    @if($orderDetail->shipmentStatus->shipment_status_name==='1')
+                                    発送前
+                                    @elseif($orderDetail->shipmentStatus->shipment_status_name==='2')
+                                    発送中
+                                    @else
+                                    発送済み
+                                    @endif
+                                @endif
                             @endforeach
                         </p>
                     </td>

--- a/resources/views/product/search.blade.php
+++ b/resources/views/product/search.blade.php
@@ -59,7 +59,7 @@
                     <tr>
                         <td>{{ $data->product_name}}</td>
                         <td>{{ $data->category->category_name}}</td>
-                        <td>{{ $data->price}}</td>
+                        <td>{{ $data->price}}円</td>
                         <td><a href="{{ route('product.show', ['id' => $data->id]) }}" class="btn btn-primary">商品詳細</a></td>
                     </tr>
                     @endforeach


### PR DESCRIPTION
■やったこと
・注文商品が複数存在する場合、注文キャンセル&注文番号が複数表示されるので1つだけ表示するように修正。
・注文キャンセル後、注文履歴にリダイレクトするように修正。
・注文詳細画面
商品詳細追加。
発送状態に関係なく、商品詳細情報は表示されるように修正。
・商品検索画面の価格に「円」追加。

kouさんと話合った結果上記の修正が必要だと感じたため修正しました。
設計書と少し違う部分はありますが、よろしいでしょうか？
確認のほど宜しくお願いします。